### PR TITLE
Update function.login-header.php to be compatible with WP 5.7

### DIFF
--- a/includes/function.login-header.php
+++ b/includes/function.login-header.php
@@ -15,7 +15,8 @@ function login_header( $title = 'Log In', $message = '', $wp_error = null ) {
 	global $error, $interim_login, $action;
 
 	// Don't index any of these forms.
-	add_action( 'login_head', 'wp_no_robots' );
+	add_filter( 'wp_robots', 'wp_robots_sensitive_page' );
+	add_action( 'login_head', 'wp_strict_cross_origin_referrer' );
 
 	add_action( 'login_head', 'wp_login_viewport_meta' );
 


### PR DESCRIPTION
wp_no_robots is deprecated since WP 5.7.

Change login_header function to mimic login_header function from wp-login.php